### PR TITLE
Add console block to module.xml

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -80,4 +80,10 @@
 	<supported>
 		<version>17.0</version>
 	</supported>
+	<console>
+		<command>
+			<name>api</name>
+			<class>Api</class>
+		</command>
+    </console>
 </module>


### PR DESCRIPTION
This PR add  the console block to the file module.xml to prevent the message "Deprecated way to add Console commands for module" for FreePBX 17

Bugfix FreePBX/issue-tracker#278